### PR TITLE
small changes in jms-provider-activemq/pom.xml for version 5.8.0

### DIFF
--- a/jms-benchmark-activemq/pom.xml
+++ b/jms-benchmark-activemq/pom.xml
@@ -38,7 +38,7 @@
     <benchmark-options></benchmark-options>
     <box>boxname</box>
     <server>server</server>
-    <activemq-version>5.5.1</activemq-version>
+    <activemq-version>5.8.0</activemq-version>
   </properties>
 
   <dependencies>
@@ -50,7 +50,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-core</artifactId>
+      <artifactId>activemq-client</artifactId>
+      <version>${activemq-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-spring</artifactId>
       <version>${activemq-version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Hi Hiram, 
since activemq 5.8.0 the activemq-core artifact does not contain classes you are importing, activemq-client and activemq-spring should probably substitute it.

Cheers,
Jiri
