### PR TITLE
Add parameters to ActiveMQ benchmark

### DIFF
--- a/bin/benchmark-activemq
+++ b/bin/benchmark-activemq
@@ -10,6 +10,10 @@
 true \
 ${SERVER_SETUP:=true} \
 ${SERVER_ADDRESS:=localhost} \
+${ACTIVEMQ_PORT:=61616} \
+${ACTIVEMQ_TRANSPORT:=tcp} \
+${ACTIVEMQ_USERNAME:="admin"} \
+${ACTIVEMQ_PASSWORD:="password"} \
 ${ACTIVEMQ_VERSION:=5.8.0} \
 ${SERVER_NAME:="activemq-${ACTIVEMQ_VERSION}"} \
 ${ACTIVEMQ_DOWNLOAD:="http://archive.apache.org/dist/activemq/apache-activemq/${ACTIVEMQ_VERSION}/apache-activemq-${ACTIVEMQ_VERSION}-bin.tar.gz"}
@@ -59,7 +63,7 @@ fi
 cd "${BASEDIR}/jms-benchmark-activemq"
 export CLASSPATH=`${MVN} -P download org.apache.maven.plugins:maven-dependency-plugin:2.7:build-classpath "-Dactivemq-version=${ACTIVEMQ_VERSION}" | grep -v "\[" | grep -v Download`
 export CLASSPATH="${CLASSPATH}:target/classes"
-benchmark --provider activemq --display-errors --url tcp://${SERVER_ADDRESS}:61616 "${REPORTS_HOME}/${SERVER_NAME}-openwire.json"
+benchmark --provider activemq --display-errors --user-name ${ACTIVEMQ_USERNAME} --password ${ACTIVEMQ_PASSWORD} --url ${ACTIVEMQ_TRANSPORT}://${SERVER_ADDRESS}:${ACTIVEMQ_PORT} "${REPORTS_HOME}/${SERVER_NAME}-openwire.json"
 
 # Kill the broker
 if [ $SERVER_SETUP == true ] ; then
@@ -67,4 +71,5 @@ if [ $SERVER_SETUP == true ] ; then
 fi
 
 # Create a report.
+cd "${BASEDIR}"
 "${BASEDIR}/bin/benchmark-report" $*

--- a/readme.md
+++ b/readme.md
@@ -51,3 +51,20 @@ the following commands on the instance:
     screen ./jms-benchmark-master/bin/benchmark-all
 
 The results will be stored in the ~/reports directory.
+
+## Benchmarking remote Activemq from an EC2 Amazon Linux 64 bit AMI
+
+    sudo yum install -y screen
+    curl https://nodeload.github.com/chirino/jms-benchmark/zip/master > jms-benchmark.zip
+    jar -xvf jms-benchmark.zip 
+    chmod a+x ./jms-benchmark-master/bin/*
+    screen env \
+      SERVER_SETUP=false \
+      SERVER_ADDRESS={activemq-endpoint} \
+      ACTIVEMQ_TRANSPORT={activemq-transport} \
+      ACTIVEMQ_PORT={activemq-port} \
+      ACTIVEMQ_USERNAME={activemq-user} \
+      ACTIVEMQ_PASSWORD={activemq-password} \
+      ./bin/benchmark-activemq
+
+The results will be stored in the ~/reports directory.


### PR DESCRIPTION
Add parameters to ActiveMQ benchmark in order to support authentication and others transports layers (ssl for instance).

Those parameters can be very helpful to benchmark managed Activemq deployments such as AmazonMQ